### PR TITLE
@jz would you believe me if I told you console logging *was* working?

### DIFF
--- a/App/App.cs
+++ b/App/App.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using Microsoft.Extensions.Logging;
 
 namespace SearchIndexer.App
 {
@@ -19,25 +20,30 @@ namespace SearchIndexer.App
             switch (_parsedArguments.RunningMode)
             {
                 case RunningMode.Create:
-                    {
-                        _logger.LogInformation("Doing some create-y stuff");
-                        break;
-                    }
+                {
+                    _logger.LogInformation("Doing some create-y stuff");
+                    break;
+                }
                 case RunningMode.Delete:
-                    {
-                        _logger.LogInformation("Doing some delete-y stuff");
-                        break;
-                    }
+                {
+                    _logger.LogInformation("Doing some delete-y stuff");
+                    break;
+                }
                 case RunningMode.Get:
-                    {
-                        _logger.LogInformation("Doing some get-y stuff");
-                        break;
-                    }
+                {
+                    _logger.LogInformation("Doing some get-y stuff");
+                    break;
+                }
                 case RunningMode.Update:
-                    {
-                        _logger.LogInformation("Doing some update-y stuff");
-                        break;
-                    }
+                {
+                    _logger.LogInformation("Doing some update-y stuff");
+                    break;
+                }
+                case RunningMode.None:
+                {
+                    _logger.LogError("No running mode was provided.");
+                    throw new ArgumentNullException(nameof(_parsedArguments.RunningMode));
+                }
                 // anything else?
                 default:
                     {

--- a/App/Program.cs
+++ b/App/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace SearchIndexer.App
 {
@@ -21,6 +22,8 @@ namespace SearchIndexer.App
         private static void Execute()
         {
             _serviceProvider.GetService<App>().Run();
+            Console.WriteLine("Press any key to terminate application.");
+            Console.ReadKey();
         }
 
     }

--- a/App/RunningMode.cs
+++ b/App/RunningMode.cs
@@ -2,6 +2,7 @@
 {
     public enum RunningMode
     {
+        None,
         Get,
         Create,
         Update,


### PR DESCRIPTION
- logging is apparently handled on a separate thread and without the console.readkey the app terminates too quickly for the console logging to process.
- as per https://github.com/aspnet/Logging/issues/631


![image](https://user-images.githubusercontent.com/8814983/55952122-c7ac9600-5c26-11e9-8522-a13998a3f135.png)
