### PR TITLE
Feature/net standard feed loader

### DIFF
--- a/InputPlugins/PodcastInputPlugin/PodcastDocumentProvider.cs
+++ b/InputPlugins/PodcastInputPlugin/PodcastDocumentProvider.cs
@@ -1,4 +1,5 @@
 ﻿using CodeHollow.FeedReader;
+using CodeHollow.FeedReader.Feeds;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using SearchIndexer.Inputs.InputPlugin;
@@ -78,9 +79,9 @@ namespace SearchIndexer.Inputs.PodcastInputPlugin
 
                 feed.Items.Select(e => new PodcastEpisode
                 {
-                    Id = GetId(md5, e.Link),
+                    Id = GetId(md5, GetAudioUrl(e.SpecificItem)),
                     Title = e.Title,
-                    AudioUrl = e.Link,
+                    AudioUrl = GetAudioUrl(e.SpecificItem),
                     // Episode = e.Episode, // TODO Not Supported by lib
                     // Season = e.Season, // TODO Not Supported by lib
                     Published = e.PublishingDateString,
@@ -96,6 +97,16 @@ namespace SearchIndexer.Inputs.PodcastInputPlugin
                 Logger.LogError(name + ex.ToString());
                 Logger.LogError($"{name} Continuing anyway");
             }
+        }
+
+        private string GetAudioUrl(BaseFeedItem specificItem)
+        {
+            if (specificItem is MediaRssFeedItem mediaItem)
+            {
+                return mediaItem.Enclosure.Url;
+            }
+
+            return specificItem.Link;
         }
 
         private string GetId(MD5 md5, string audioFileUrl)

--- a/InputPlugins/PodcastInputPlugin/PodcastDocumentProvider.cs
+++ b/InputPlugins/PodcastInputPlugin/PodcastDocumentProvider.cs
@@ -1,4 +1,4 @@
-﻿using iPodcastSearch;
+﻿using CodeHollow.FeedReader;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using SearchIndexer.Inputs.InputPlugin;
@@ -72,20 +72,20 @@ namespace SearchIndexer.Inputs.PodcastInputPlugin
             try
             {
                 Logger.LogInformation($"{name} Downloading and parsing");
-                var feed = PodcastFeedParser.LoadFeedAsync(feedMetaData.FeedUrl).Result;
+                var feed = FeedReader.ReadAsync(feedMetaData.FeedUrl).Result;
                 sw.Stop();
-                Logger.LogInformation($"{name} Loaded the feed, {feed.EpisodeCount} episode(s) found in {sw.Elapsed.TotalSeconds}s");
+                Logger.LogInformation($"{name} Loaded the feed, {feed.Items.Count} episode(s) found in {sw.Elapsed.TotalSeconds}s");
 
-                feed.Episodes.Select(e => new PodcastEpisode
+                feed.Items.Select(e => new PodcastEpisode
                 {
-                    Id = GetId(md5, e.AudioFileUrl),
-                    Title = feed.Name,
-                    AudioUrl = e.AudioFileUrl,
+                    Id = GetId(md5, e.Link),
+                    Title = e.Title,
+                    AudioUrl = e.Link,
                     // Episode = e.Episode, // TODO Not Supported by lib
                     // Season = e.Season, // TODO Not Supported by lib
-                    Published = e.PubDate.ToShortDateString(),
+                    Published = e.PublishingDateString,
                     Description = e.Description,
-                    Feed = feed.FeedUrl
+                    Feed = feedMetaData.FeedUrl
                 }).ToList()
                 .ForEach(e => destination.Add(e as IDocument));
             }

--- a/InputPlugins/PodcastInputPlugin/PodcastInputPlugin.csproj
+++ b/InputPlugins/PodcastInputPlugin/PodcastInputPlugin.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iPodcastSearch" Version="1.0.0" />
+    <PackageReference Include="CodeHollow.FeedReader" Version="1.1.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />


### PR DESCRIPTION
Fixes #7.
- Netstandard RSS reader (non specific to podcasts, had to traverse the XML a lil bit in order to get the audio URL.
- It didn't look like the old NuGet package was grabbing the date properly (at least when testing with the first item from the feed.json) - that should be fixed now, though I used their already stringified date.
- The show notes URL are available in this document as well, though I did not project them onto your object.